### PR TITLE
updates mongoose connection to use production env variable for mongo

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -13,10 +13,7 @@ const app = express()
 
 app.use(
     cors({
-        origin: [
-            "https://dnvr-zero-be.vercel.app/task",
-            "http://localhost:3000",
-        ],
+        origin: ["https://dnvr-zero-be.vercel.app", "http://localhost:3000"],
     })
 )
 
@@ -78,16 +75,28 @@ const MONGODB_URI =
         : process.env.DEVELOPMENT_DB_CONNECTION
 
 // Database connection
-mongoose
-    .connect(MONGODB_URI, {
-        useNewUrlParser: true,
-        useUnifiedTopology: true,
-    })
-    .then(() => console.log("DB Connected "))
-    .catch((err) => console.log("error"))
+if (process.env.MONGODB_URI) {
+    mongoose
+        .connect(process.env.MONGODB_URI, {
+            useNewUrlParser: true,
+            useUnifiedTopology: true,
+        })
+        .then(() => console.log("DB Connected "))
+        .catch((err) => console.log("error"))
+} else {
+    mongoose
+        .connect(MONGODB_URI, {
+            useNewUrlParser: true,
+            useUnifiedTopology: true,
+        })
+        .then(() => console.log("DB Connected "))
+        .catch((err) => console.log("error"))
+}
 
-if(process.env.NODE_ENV !== "test") {  
-app.listen(process.env.PORT, () => console.log(`App listening at port ${process.env.PORT}`));
-};
+if (process.env.NODE_ENV !== "test") {
+    app.listen(process.env.PORT, () =>
+        console.log(`App listening at port ${process.env.PORT}`)
+    )
+}
 // module.exports = app
 export default app


### PR DESCRIPTION
# What does this PR do? 
- creates an `if/else` statement for the mongodb connection

# How does this PR accomplish that? 

```js
// the production ENV variable is accessible, per [Vercel docs](https://vercel.com/docs/concepts/projects/environment-variables), at `process.env.<KEY-NAME>`, which I think has been subject to some edits recently

if (process.env.MONGODB_URI) {
    mongoose
        .connect(process.env.MONGODB_URI, {
            useNewUrlParser: true,
            useUnifiedTopology: true,
        })
        .then(() => console.log("DB Connected "))
        .catch((err) => console.log("error"))
} else {
    mongoose
        .connect(MONGODB_URI, {
            useNewUrlParser: true,
            useUnifiedTopology: true,
        })
        .then(() => console.log("DB Connected "))
        .catch((err) => console.log("error"))
};
```
